### PR TITLE
Hides gencon page

### DIFF
--- a/conventions/gencon.html
+++ b/conventions/gencon.html
@@ -4,6 +4,7 @@ heading: Join the Stillfleet Studio team at Gen Con 2024 for games, playtesting,
 title: Bringin the indie to Indy
 slug: conventions
 # permalink: /conventions/
+published: false
 ---
 
   <p>First of all, if you play Grit System games and/or swing Left and like RPGs, then we’d love to meet you. Aaron, Chris, Kae, and Wythe will be at the Con Friday–Sunday. Ping us on <a href="http://discord.stillfleet.com/">Discord</a> to say hi!


### PR DESCRIPTION
Hides the gencon page for now, since the convention has passed.
